### PR TITLE
CI: Unify configurations across the different builds

### DIFF
--- a/.github/workflows/ci-ppa.yml
+++ b/.github/workflows/ci-ppa.yml
@@ -23,12 +23,9 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq grass grass-dev grass-doc
-    - name: Change shebang to just Python (7.6 needs python2)
-      run: |
-        sed -i s/python3/python/g testsuite/test_r_pops_spread.py
     - name: Install the module
       run: |
-        grass --tmp-location XY --exec g.extension extension=${{ github.event.repository.name }} url=. --verbose
+        grass --tmp-location XY --exec g.extension extension=r.pops.spread url=. --verbose
     - name: Cache data for testing
       id: cache-nc_spm_08_grass7
       uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
-- push
-- pull_request
+  push:
+  pull_request:
+  schedule:
+  # 01:00 Pacific Time (in UTC), every month on 10th
+  - cron:  '0 8 10 * *'
 
 jobs:
   build:
@@ -31,7 +34,7 @@ jobs:
         sed -i s/python3/python/g testsuite/test_r_pops_spread.py
     - name: Install the module
       run: |
-        grass ~/grasstmploc/PERMANENT --exec g.extension extension=${{ github.event.repository.name }} url=. --verbose
+        grass ~/grasstmploc/PERMANENT --exec g.extension extension=r.pops.spread url=. --verbose
     - name: Cache data for testing
       id: cache-nc_spm_08_grass7
       uses: actions/cache@v1


### PR DESCRIPTION
All use hardcoded extension name instead of event to work with scheduled workflows.
The basic Ubuntu 18.04 package test runs once a month.
PPA now has 7.8, so no need to switch Python 3 shebang.
