### PR TITLE
Add a separate section on how to cite PoPS and clarify authors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.0.3
-message: If you use this software, please cite it as below.
+message: If you use this software, please cite it using the references in the readme (this file is outdated).
 authors:
   - family-names: Petras
     given-names: Vaclav

--- a/README.md
+++ b/README.md
@@ -26,25 +26,41 @@ from this repository (see below).
 Note: Earlier versions of this module were called *r.spread.pest* and
 *r.spread.sod*.
 
-## References
+## How to cite
 
-Please, in addition to citing or acknowledging this software
-(see [CITATION file](CITATION.cff)), cite the following papers:
+If you use this software or code, please cite the following papers:
 
-Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
-Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan 2011.
-Epidemiological modeling of invasion in heterogeneous landscapes:
-spread of sudden oak death in California (1990–2030).
-*Ecosphere* 2:art17.
-[DOI: 10.1890/ES10-00192.1](https://doi.org/10.1890/ES10-00192.1)
+* Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe,
+  Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan, 2011.
+  Epidemiological modeling of invasion in heterogeneous landscapes:
+  spread of sudden oak death in California (1990–2030).
+  *Ecosphere* 2:art17.
+  [DOI: 10.1890/ES10-00192.1](https://doi.org/10.1890/ES10-00192.1)
 
-Tonini, Francesco, Douglas Shoemaker, Anna Petrasova, Brendan Harmon,
-Vaclav Petras, Richard C. Cobb, Helena Mitasova,
-and Ross K. Meentemeyer.
-Tangible geospatial modeling for collaborative solutions
-to invasive species management.
-*Environmental Modelling & Software* 92 (2017): 176-188.
-[DOI: 10.1016/j.envsoft.2017.02.020](https://doi.org/10.1016/j.envsoft.2017.02.020)
+* Tonini, Francesco, Douglas Shoemaker, Anna Petrasova, Brendan Harmon,
+  Vaclav Petras, Richard C. Cobb, Helena Mitasova,
+  and Ross K. Meentemeyer, 2017.
+  Tangible geospatial modeling for collaborative solutions
+  to invasive species management.
+  *Environmental Modelling & Software* 92: 176-188.
+  [DOI: 10.1016/j.envsoft.2017.02.020](https://doi.org/10.1016/j.envsoft.2017.02.020)
+
+In case you are using the automatic management feature in rpops or the
+steering version of r.pops.spread (from the branch steering), please
+cite also:
+
+* Petrasova, A., Gaydos, D.A., Petras, V., Jones, C.M., Mitasova, H. and
+  Meentemeyer, R.K., 2020.
+  Geospatial simulation steering for adaptive management.
+  *Environmental Modelling & Software* 133: 104801.
+  [DOI: 10.1016/j.envsoft.2020.104801](https://doi.org/10.1016/j.envsoft.2020.104801)
+
+In addition to citing the above paper, we also encourage you to
+reference, link, and/or acknowledge specific version of the software
+you are using for example:
+
+* *We have used rpops R package version 1.0.0 from
+  <https://github.com/ncsu-landscape-dynamics/rpops>*.
 
 ## Obtaining the latest code
 
@@ -121,16 +137,32 @@ Run:
 
     grass .../modeling/scenario1 --exec r.pops.spread ...
 
-## Authors
+## Authors and contributors
 
-* Francesco Tonini (original R version)
-* Zexi Chen (initial C++ version)
-* Vaclav Petras (parallelization, GRASS interface, raster handling, ...)
-* Anna Petrasova (single species simulation)
+### Authors
 
-See [CHANGELOG.md](CHANGELOG.md) for details about contributions.
+_(alphabetical order)_
+
+* Chris Jones
+* Margaret Lawrimore
+* Vaclav Petras
+* Anna Petrasova
+
+### Previous contributors
+
+_(alphabetical order)_
+
+* Zexi Chen
+* Devon Gaydos
+* Francesco Tonini
+
+See Git commit history, GitHub insights, or CHANGELOG.md file (if present)
+for details about contributions.
 
 ## License
 
-This program is free software under the GNU General Public License
-(>=v2). Read the file LICENSE for details.
+Permission to use, copy, modify, and distribute this software and its documentation
+under the terms of the GNU General Public License version 2 or higher is hereby
+granted. No representations are made about the suitability of this software for any
+purpose. It is provided "as is" without express or implied warranty.
+See the GNU General Public License for more details.


### PR DESCRIPTION
This is a new How to cite section (the two papers to be replaced with Jones 2020) and
restructured Authors and contributors section. Both are to be fully synced/copied from PoPS.
