### PR TITLE
Update PoPS Core repo URL and branch name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pops"]
 	path = pops-core
-	url = https://github.com/ncsu-landscape-dynamics/PoPS.git
-	branch = master
+	url = https://github.com/ncsu-landscape-dynamics/pops-core.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -108,16 +108,19 @@ to changes in the submodule repository.
 ### Updating the code of the submodule
 
 ```
-cd pops
-git checkout master
+cd pops-core
+git switch -c new-feature-branch
 git add file.hpp
 git commit -m "this and that change"
 git push
 ```
 
+Then create a PR. After the PR is merged, then update the submodule and commit:
+
 ```
 cd ..
-git commit pops -m "update to latest pops commit"
+git submodule update --remote
+git commit pops-core -m "update to latest pops commit"
 git push
 ```
 


### PR DESCRIPTION
* Old PoPS repo is now pops-core.
* Old pops directory for Git submodule is now pops-core.
* Old master branch is now main.