### PR TITLE
Update to new branch names in GRASS (master to main)

### DIFF
--- a/.github/workflows/ci-compiled.yml
+++ b/.github/workflows/ci-compiled.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - version: master
+        - version: main
           command: grass
         - version: releasebranch_7_8
           command: grass78


### PR DESCRIPTION
The master branch in core was renamed to main.