### PR TITLE
Add survival rate parameter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -439,6 +439,14 @@ int main(int argc, char *argv[])
 
     // Survival rate
 
+    opt.survival_rate_file = G_define_standard_option(G_OPT_F_INPUT);
+    opt.survival_rate_file->key = "survival_rate";
+    opt.survival_rate_file->label =
+        _("Input file with one survival rate raster map name per line");
+    opt.survival_rate_file->description = _("Suvival rate is percentage (0-1)");
+    opt.survival_rate_file->required = NO;
+    opt.survival_rate_file->guisection = _("Weather");
+
     opt.survival_rate_month = G_define_option();
     opt.survival_rate_month->type = TYPE_INTEGER;
     opt.survival_rate_month->key = "survival_month";
@@ -458,14 +466,6 @@ int main(int argc, char *argv[])
         _("The survival rate is applied at the selected month and day");
     opt.survival_rate_day->required = NO;
     opt.survival_rate_day->guisection = _("Weather");
-
-    opt.survival_rate_file = G_define_standard_option(G_OPT_F_INPUT);
-    opt.survival_rate_file->key = "survival_rate";
-    opt.survival_rate_file->label =
-        _("Input file with one survival rate raster map name per line");
-    opt.survival_rate_file->description = _("Suvival rate is percentage (0-1)");
-    opt.survival_rate_file->required = NO;
-    opt.survival_rate_file->guisection = _("Weather");
 
     // Temperature and lethal temperature
 
@@ -958,15 +958,16 @@ int main(int argc, char *argv[])
     unsigned seed_value;
     if (opt.seed->answer) {
         seed_value = std::stoul(opt.seed->answer);
-        G_verbose_message(_("Read random seed from %s option: %ud"),
-                          opt.seed->key, seed_value);
-    } else {
+        G_verbose_message(
+            _("Read random seed from %s option: %u"), opt.seed->key, seed_value);
+    }
+    else {
         // flag or option is required, so no check needed
         // getting random seed using GRASS library
         // std::random_device is deterministic in MinGW (#338)
         seed_value = G_srand48_auto();
-        G_verbose_message(_("Generated random seed (-%c): %ud"),
-                          flg.generate_seed->key, seed_value);
+        G_verbose_message(
+            _("Generated random seed (-%c): %u"), flg.generate_seed->key, seed_value);
     }
 
     // read the suspectible UMCA raster image
@@ -1102,6 +1103,8 @@ int main(int argc, char *argv[])
 
     std::vector<unsigned> unresolved_steps;
     unresolved_steps.reserve(config.scheduler().get_num_steps());
+
+    G_verbose_message(_("Number of steps: %u"), config.scheduler().get_num_steps());
 
     // main simulation loop
     unsigned current_index = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -443,9 +443,9 @@ int main(int argc, char *argv[])
     opt.survival_rate_month->type = TYPE_INTEGER;
     opt.survival_rate_month->key = "survival_month";
     opt.survival_rate_month->label =
-        _("Month when the pest or pathogen dies due to low temperature");
+        _("Month when the pest or pathogen dies with given rate");
     opt.survival_rate_month->description =
-        _("The survival rate is applied at selected month and day");
+        _("The survival rate is applied at the selected month and day");
     opt.survival_rate_month->required = NO;
     opt.survival_rate_month->guisection = _("Weather");
 
@@ -455,7 +455,7 @@ int main(int argc, char *argv[])
     opt.survival_rate_day->label =
         _("Day of selected month when the pest or pathogen dies with given rate");
     opt.survival_rate_day->description =
-        _("The survival rate is applied at selected month and day");
+        _("The survival rate is applied at the selected month and day");
     opt.survival_rate_day->required = NO;
     opt.survival_rate_day->guisection = _("Weather");
 
@@ -463,8 +463,7 @@ int main(int argc, char *argv[])
     opt.survival_rate_file->key = "survival_rate";
     opt.survival_rate_file->label =
         _("Input file with one survival rate raster map name per line");
-    opt.survival_rate_file->description =
-        _("Suvival rate is percentage (0-1)");
+    opt.survival_rate_file->description = _("Suvival rate is percentage (0-1)");
     opt.survival_rate_file->required = NO;
     opt.survival_rate_file->guisection = _("Weather");
 
@@ -486,7 +485,7 @@ int main(int argc, char *argv[])
     opt.lethal_temperature_months->type = TYPE_INTEGER;
     opt.lethal_temperature_months->key = "lethal_month";
     opt.lethal_temperature_months->label =
-        _("Month when the pest or patogen dies due to low temperature");
+        _("Month when the pest or pathogen dies due to low temperature");
     opt.lethal_temperature_months->description =
         _("The temperature unit must be the same as for the"
           "temperature raster map (typically degrees of Celsius)");
@@ -1005,7 +1004,8 @@ int main(int argc, char *argv[])
 
     std::vector<DImg> survival_rates;
     if (opt.survival_rate_file->answer) {
-        survival_rates = file_to_series(opt.survival_rate_file, config.num_survival_rate());
+        survival_rates =
+            file_to_series(opt.survival_rate_file, config.num_survival_rate());
     }
 
     std::vector<DImg> actual_temperatures;

--- a/main.cpp
+++ b/main.cpp
@@ -136,6 +136,11 @@ unsigned int get_num_answers(struct Option *opt)
     return i;
 }
 
+/** Read list of names from a file
+ *
+ * Assumes one name per line. The current implementation basically splits the file by
+ * lines and returns the resulting list of strings.
+ */
 std::vector<string> read_names(const char* filename)
 {
     std::vector<string> names;
@@ -147,6 +152,11 @@ std::vector<string> read_names(const char* filename)
     return names;
 }
 
+/** From a file option representing a raster series, create series of rasters.
+ *
+ * Calls fatal error if the input is not correct. It will read all rasters if there is
+ * more than needed.
+ */
 std::vector<DImg> file_to_series(struct Option* option, int expected) {
     file_exists_or_fatal_error(option);
     auto names{read_names(option->answer)};

--- a/main.cpp
+++ b/main.cpp
@@ -443,7 +443,7 @@ int main(int argc, char *argv[])
     opt.survival_rate_month->type = TYPE_INTEGER;
     opt.survival_rate_month->key = "survival_month";
     opt.survival_rate_month->label =
-        _("Month when the pest or patogen dies due to low temperature");
+        _("Month when the pest or pathogen dies due to low temperature");
     opt.survival_rate_month->description =
         _("The survival rate is applied at selected month and day");
     opt.survival_rate_month->required = NO;
@@ -453,7 +453,7 @@ int main(int argc, char *argv[])
     opt.survival_rate_day->type = TYPE_INTEGER;
     opt.survival_rate_day->key = "survival_day";
     opt.survival_rate_day->label =
-        _("Day of selected month when the pest or patogen dies with given rate");
+        _("Day of selected month when the pest or pathogen dies with given rate");
     opt.survival_rate_day->description =
         _("The survival rate is applied at selected month and day");
     opt.survival_rate_day->required = NO;
@@ -462,7 +462,7 @@ int main(int argc, char *argv[])
     opt.survival_rate_file = G_define_standard_option(G_OPT_F_INPUT);
     opt.survival_rate_file->key = "survival_rate";
     opt.survival_rate_file->label =
-        _("Input file with one suvival rate raster map name per line");
+        _("Input file with one survival rate raster map name per line");
     opt.survival_rate_file->description =
         _("Suvival rate is percentage (0-1)");
     opt.survival_rate_file->required = NO;
@@ -919,9 +919,9 @@ int main(int argc, char *argv[])
         config.mortality_frequency_n = opt.mortality_frequency_n->answer ? std::stoi(opt.mortality_frequency_n->answer) : 0;
     }
 
-    if (opt.lethal_temperature_months->answer)
+    if (opt.survival_rate_month->answer)
         config.survival_rate_month = std::stoi(opt.survival_rate_month->answer);
-    if (opt.lethal_temperature->answer)
+    if (opt.survival_rate_day->answer)
         config.survival_rate_day = std::stod(opt.survival_rate_day->answer);
     if (opt.survival_rate_file->answer)
         config.use_survival_rate = true;


### PR DESCRIPTION
The addition of survival rate requires an additional parameter plus date settings. This adds it as a input raster series and generalizes code for reading raster names for raster series from a file which is common between survival rate and temperatures. Tests are for 100% and 0% survival rate.

Additionally, this adds number of steps as verbose message and fixes seed print (extra char d in output).