### PR TITLE
Remove PDAL dependency from build

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -47,7 +47,8 @@ cd grass
     --with-geos \
     --with-sqlite \
     --with-fftw \
-    --with-netcdf
+    --with-netcdf \
+    --without-pdal
 
 make
 make install


### PR DESCRIPTION
PDAL is not not needed and we don't install it, but newly it is enabled by default. This disables it.
