### PR TITLE
CI: Remove GRASS GIS 7.8

### DIFF
--- a/.github/workflows/ci-compiled.yml
+++ b/.github/workflows/ci-compiled.yml
@@ -27,8 +27,6 @@ jobs:
           command: grass
         - version: releasebranch_8_0
           command: grass
-        - version: releasebranch_7_8
-          command: grass78
       fail-fast: false
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This removes GRASS GIS 7.8 because we don't need to support it anymore and it lacks some testing features useful in #61 (assertRastersEqual).
