### PR TITLE
Add dispersers output

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1627,7 +1627,7 @@ int main(int argc, char* argv[])
         G_close_option_file(fp);
     }
     if (opt.dispersers_output->answer) {
-        DImg dispersers_rasts_sum(I_species_rast.rows(), I_species_rast.cols(), 0);
+        Img dispersers_rasts_sum(I_species_rast.rows(), I_species_rast.cols(), 0);
         for (unsigned i = 0; i < num_runs; i++)
             dispersers_rasts_sum += dispersers_rasts[i];
         if (opt.dispersers_output->answer) {
@@ -1640,7 +1640,7 @@ int main(int argc, char* argv[])
         }
     }
     if (opt.established_dispersers_output->answer) {
-        DImg established_dispersers_rasts_sum(I_species_rast.rows(), I_species_rast.cols(), 0);
+        Img established_dispersers_rasts_sum(I_species_rast.rows(), I_species_rast.cols(), 0);
         for (unsigned i = 0; i < num_runs; i++)
             established_dispersers_rasts_sum += established_dispersers_rasts[i];
         if (opt.established_dispersers_output->answer) {

--- a/testsuite/test_r_pops_spread.py
+++ b/testsuite/test_r_pops_spread.py
@@ -191,7 +191,7 @@ class TestSpread(TestCase):
             "g.remove",
             flags="f",
             type="raster",
-            pattern="average*,single*,stddev*,probability*,dead*",
+            pattern="average*,single*,stddev*,probability*,dead*,*dispersers",
         )
 
     def test_outputs(self):
@@ -1405,6 +1405,53 @@ class TestSpread(TestCase):
         )
         # Even with multiple runs, stddev should be still zero.
         self.assertRasterFitsUnivar(raster="stddev", reference=values, precision=0.001)
+
+    def test_outputs_dispersers(self):
+        """Check dead output of mortality"""
+        start = "2019-01-01"
+        end = "2022-12-31"
+        self.assertModule(
+            "r.pops.spread",
+            host="host",
+            total_plants="max_host",
+            infected="infection",
+            average="average",
+            average_series="average",
+            single_series="single",
+            stddev="stddev",
+            stddev_series="stddev",
+            probability="probability",
+            probability_series="probability",
+            start_date=start,
+            end_date=end,
+            seasonality=[1, 12],
+            step_unit="week",
+            step_num_units=1,
+            reproductive_rate=1,
+            natural_dispersal_kernel="exponential",
+            natural_distance=50,
+            natural_direction="W",
+            natural_direction_strength=3,
+            anthropogenic_dispersal_kernel="cauchy",
+            anthropogenic_distance=1000,
+            anthropogenic_direction_strength=0,
+            percent_natural_dispersal=0.95,
+            random_seed=1,
+            runs=5,
+            nprocs=5,
+            dispersers_output="dispersers",
+            established_dispersers_output="established_dispersers",
+        )
+        end = end[:4]
+        self.assertRasterExists("dispersers")
+        self.assertRasterExists("established_dispersers")
+
+        values = dict(null_cells=0, min=0, max=15530, mean=522.275)
+        self.assertRasterFitsUnivar(raster="dispersers", reference=values, precision=0.001)
+        values = dict(null_cells=0, min=0, max=129, mean=8.833)
+        self.assertRasterFitsUnivar(
+            raster="established_dispersers", reference=values, precision=0.001
+        )
 
     def test_with_and_without_anthropogenic_dispersal_multiple_seeds(self):
         """Check that multiple seeds keep anthropogenic dispersal separate

--- a/testsuite/test_r_pops_spread.py
+++ b/testsuite/test_r_pops_spread.py
@@ -1442,12 +1442,13 @@ class TestSpread(TestCase):
             dispersers_output="dispersers",
             established_dispersers_output="established_dispersers",
         )
-        end = end[:4]
         self.assertRasterExists("dispersers")
         self.assertRasterExists("established_dispersers")
 
         values = dict(null_cells=0, min=0, max=15530, mean=522.275)
-        self.assertRasterFitsUnivar(raster="dispersers", reference=values, precision=0.001)
+        self.assertRasterFitsUnivar(
+            raster="dispersers", reference=values, precision=0.001
+        )
         values = dict(null_cells=0, min=0, max=129, mean=8.833)
         self.assertRasterFitsUnivar(
             raster="established_dispersers", reference=values, precision=0.001


### PR DESCRIPTION
Sums all generated and established dispersers over all steps and stochastic runs. Alternatively it could average them over stochastic runs.