### PR TITLE
CI: Update Ubuntu version

### DIFF
--- a/.github/workflows/ci-ppa.yml
+++ b/.github/workflows/ci-ppa.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Update Ubuntu to the next LTS.

Motivation is a failing add-PPA step which translates ppa:ubuntugis/ubuntugis-unstable to ppa:~ubuntugis/ubuntu/ubuntugis-unstable which fails because ubuntu/ubuntugis-unstable does not exist.
