### PR TITLE
Add regression test for mortality time lag

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1129,7 +1129,7 @@ int main(int argc, char* argv[])
         if (config.mortality_time_lag > num_mortality_steps) {
             G_fatal_error(
                 _("%s is too large (%d). It must be smaller than "
-                  " or equal to the number of simulation years (%d)."),
+                  "or equal to the number of simulation steps (%d)."),
                 opt.first_year_to_die->key,
                 config.mortality_time_lag,
                 num_mortality_steps);

--- a/main.cpp
+++ b/main.cpp
@@ -1128,8 +1128,8 @@ int main(int argc, char* argv[])
     if (flg.mortality->answer) {
         if (config.mortality_time_lag > num_mortality_steps) {
             G_fatal_error(
-                _("%s is too large (%d). It must be smaller or "
-                  " equal than number of simulation years (%d)."),
+                _("%s is too large (%d). It must be smaller than "
+                  " or equal to the number of simulation years (%d)."),
                 opt.first_year_to_die->key,
                 config.mortality_time_lag,
                 num_mortality_steps);

--- a/testsuite/test_r_pops_spread.py
+++ b/testsuite/test_r_pops_spread.py
@@ -833,6 +833,59 @@ class TestSpread(TestCase):
             raster=f"dead_{end}_12_31", reference=values, precision=0.001
         )
 
+    def test_outputs_mortality_time_lag(self):
+        """Check dead output of mortality with mortality time lag"""
+        start = "2019-01-01"
+        end = "2022-12-31"
+        self.assertModule(
+            "r.pops.spread",
+            host="host",
+            total_plants="max_host",
+            infected="infection",
+            average="average",
+            average_series="average",
+            single_series="single",
+            stddev="stddev",
+            stddev_series="stddev",
+            probability="probability",
+            probability_series="probability",
+            start_date=start,
+            end_date=end,
+            seasonality=[1, 12],
+            step_unit="week",
+            step_num_units=1,
+            reproductive_rate=1,
+            natural_dispersal_kernel="exponential",
+            natural_distance=50,
+            natural_direction="W",
+            natural_direction_strength=3,
+            anthropogenic_dispersal_kernel="cauchy",
+            anthropogenic_distance=1000,
+            anthropogenic_direction_strength=0,
+            percent_natural_dispersal=0.95,
+            random_seed=1,
+            runs=5,
+            nprocs=5,
+            flags="m",
+            mortality_rate=0.5,
+            mortality_time_lag=2,
+            mortality_series="dead",
+            mortality_frequency="yearly",
+        )
+        end = end[:4]
+        self.assertRasterExists(f"dead_{end}_12_31")
+
+        values = dict(null_cells=0, min=0, max=12.4, mean=1.562)
+        self.assertRasterFitsUnivar(raster="average", reference=values, precision=0.001)
+        values = dict(null_cells=0, min=0, max=100, mean=33.082)
+        self.assertRasterFitsUnivar(
+            raster="probability", reference=values, precision=0.001
+        )
+        values = dict(null_cells=0, min=0, max=12, mean=0.205)
+        self.assertRasterFitsUnivar(
+            raster=f"dead_{end}_12_31", reference=values, precision=0.001
+        )
+
     def test_outputs_mortality_enabled_rate_0(self):
         """Check with mortality rate 0 (values copied from basic outputs test)"""
         start = "2019-01-01"

--- a/testsuite/test_r_pops_spread.py
+++ b/testsuite/test_r_pops_spread.py
@@ -834,7 +834,11 @@ class TestSpread(TestCase):
         )
 
     def test_outputs_mortality_time_lag(self):
-        """Check dead output of mortality with mortality time lag"""
+        """Check dead output of mortality with mortality time lag
+
+        Lag keeps hosts alive longer to spread the disease, giving more
+        infection and fewer dead hosts than lag=0 (test_outputs_mortality).
+        """
         start = "2019-01-01"
         end = "2022-12-31"
         self.assertModule(


### PR DESCRIPTION
While mortality was tested, there was no test for non-zero mortality time lag. This adds a test based on the test with lag=0. The currently produced values indicate more infection and less dead hosts with lag=2 than with lag=0 and these currently produced values are used as a reference in the test.
