### PR TITLE
Update GRASS name

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -23,7 +23,7 @@ BRANCH="$3"
 
 cd $WORKDIR
 
-# GRASS GIS
+# GRASS build
 
 git clone https://github.com/OSGeo/grass.git --branch "$BRANCH" --depth=1
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -55,7 +55,7 @@ make install
 # Delete the source code.
 # The source code should not be needed anymore and
 # it may cause problems when it is in the same directory used further
-# for the compilation of the module itself
+# for the compilation of the tool itself
 # (e.g., g.extension will recurse to it).
 cd ..
 rm -rf grass

--- a/.github/workflows/ci-compiled.yml
+++ b/.github/workflows/ci-compiled.yml
@@ -1,4 +1,4 @@
-name: CI with latest GRASS GIS
+name: CI with latest GRASS
 
 on:
   push:
@@ -48,16 +48,16 @@ jobs:
     - name: Set number of cores for compilation
       run: |
         echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
-    - name: Set LD_LIBRARY_PATH for GRASS GIS compilation
+    - name: Set LD_LIBRARY_PATH for GRASS compilation
       run: |
         echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
-    - name: Get and build GRASS GIS
+    - name: Get and build GRASS
       run: |
         .github/workflows/build.sh /tmp $HOME/install ${{ matrix.version }}
     - name: Add the bin directory to PATH
       run: |
         echo "$HOME/install/bin" >> $GITHUB_PATH
-    - name: Get GRASS GIS version
+    - name: Get GRASS version
       run: |
         grass --version
     - name: Install the module

--- a/.github/workflows/ci-ppa.yml
+++ b/.github/workflows/ci-ppa.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Add PPA
       run: |
         sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-    - name: Install GRASS GIS and other dependencies
+    - name: Install GRASS and other dependencies
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq grass grass-dev grass-doc
@@ -33,7 +33,7 @@ jobs:
       run: |
         python3 --version
         python --version
-    - name: Get GRASS GIS version
+    - name: Get GRASS version
       run: |
         grass --version
     - name: Install the module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ headings instead of release numbers.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-The module follows releases of the pops-core library. Each version has the same
+The tool follows releases of the pops-core library. Each version has the same
 version number as the version of the pops-core library it uses.
 To keep versions synchornized, when this interface or rpops creates release,
 pops-core still increstes its version number even when there were no changes in

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,6 @@ authors:
     given-names: Margaret A.
     orcid: https://orcid.org/0000-0003-2266-3588
 date-released: 2021-12-15
-title: r.pops.spread - PoPS model implemented as a GRASS GIS module
+title: r.pops.spread - PoPS model implemented as a GRASS tool
 version: 2.0.0
 license: GPL-2.0-or-later

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5160178.svg)](https://doi.org/10.5281/zenodo.5160178)
 
-This is a GRASS GIS module *r.pops.spread* for simulating spread of
-pests and pathogens. The module is a GRASS GIS interface to the PoPS
+This is a GRASS tool *r.pops.spread* for simulating spread of
+pests and pathogens. The tool is a GRASS interface to the PoPS
 (Pest or Pathogen Spread) model implemented in C++ library maintained
 in the [PoPS Core repository](https://github.com/ncsu-landscape-dynamics/pops-core).
 
-The purpose of the *r.pops.spread* module is to provide easy way of
-running the model in GRASS GIS environment once you have calibrated
+The purpose of the *r.pops.spread* tool is to provide easy way of
+running the model in GRASS environment once you have calibrated
 the model for your purposes. You can obtain the calibration from a
 colleague or published work or you can calibrate the model manually (in
-GRASS GIS) or use the R interface to PoPS called
+GRASS) or use the R interface to PoPS called
 [rpops](https://github.com/ncsu-landscape-dynamics/rpops) to do that.
 
-Note: Earlier versions of this module were called *r.spread.pest* and
+Note: Earlier versions of this tool were called *r.spread.pest* and
 *r.spread.sod*.
 
 ## How to cite
@@ -42,7 +42,7 @@ In addition to citing the above paper, we also encourage you to
 reference, link, and/or acknowledge specific version of the software
 you are using, for example:
 
-* *We have used r.pops.spread GRASS module version 1.0.2 from
+* *We have used r.pops.spread GRASS tool version 1.0.2 from
   <https://github.com/ncsu-landscape-dynamics/r.pops.spread>
   [DOI: 10.5281/zenodo.5160179](https://doi.org/10.5281/zenodo.5160179)*.
 
@@ -53,8 +53,8 @@ You can find the DOI for the specific version you are using at
 
 ### Download and install
 
-The latest release of the *r.pops.spread* module is available in GRASS GIS Addons repository
-and can be installed directly in GRASS GIS through graphical user
+The latest release of the *r.pops.spread* tool is available in GRASS Addons repository
+and can be installed directly in GRASS through graphical user
 interface or using the following command:
 
 ```
@@ -149,7 +149,7 @@ Compile:
 
     grass --tmp-location XY --exec g.extension module=r.pops.spread url=.
 
-Run (assuming you checked how to create a GRASS GIS mapset with our data):
+Run (assuming you checked how to create a GRASS mapset with our data):
 
     grass .../modeling/scenario1 --exec r.pops.spread ...
 

--- a/TECHNICALDEBT.md
+++ b/TECHNICALDEBT.md
@@ -108,4 +108,4 @@ optionally linked in an entry.
 - Some of the Date class methods have still misleading names (e.g.,
   increased versus increase).
 - Methods and functions should use underscores not camel case (using
-  Python and GRASS GIS convention).
+  Python and GRASS convention).

--- a/graster.hpp
+++ b/graster.hpp
@@ -1,5 +1,5 @@
 /*
- * PoPS model - Reading and writing GRASS GIS rasters as Raster
+ * PoPS model - Reading and writing GRASS rasters as Raster
  *
  * Copyright (C) 2019 by the authors.
  *
@@ -29,7 +29,7 @@ extern "C" {
 #include <string>
 #include <type_traits>
 
-/** Convert pops::Date to GRASS GIS TimeStamp */
+/** Convert pops::Date to GRASS TimeStamp */
 void date_to_grass(pops::Date date, struct TimeStamp* timestamp)
 {
     struct DateTime date_time;
@@ -80,7 +80,7 @@ inline bool grass_raster_is_null_value(const CELL* value)
     return Rast_is_c_null_value(value);
 }
 
-/** Set a value to zero (0) if it is null (GRASS GIS NULL) */
+/** Set a value to zero (0) if it is null (GRASS NULL) */
 template<typename Number>
 inline void set_null_to_zero(Number* value)
 {
@@ -146,7 +146,7 @@ enum class NullOutputPolicy
 // point in doing any conversions, so using it as default.
 constexpr auto DefaultNullOutputPolicy = NullOutputPolicy::NoConversions;
 
-/** Read a GRASS GIS raster map to the Raster
+/** Read a GRASS raster map to the Raster
  *
  * The caller is required to specify the type of the raster as a
  * template parameter:
@@ -155,7 +155,7 @@ constexpr auto DefaultNullOutputPolicy = NullOutputPolicy::NoConversions;
  * raster_from_grass<double>(name)
  * ````
  *
- * Given the types of GRASS GIS raster maps, it supports only
+ * Given the types of GRASS raster maps, it supports only
  * int, float, and double (CELL, FCELL, and DCELL).
  */
 template<typename Number>
@@ -190,7 +190,7 @@ inline pops::Raster<Number> raster_from_grass(
     return raster_from_grass<Number>(name.c_str(), null_policy);
 }
 
-/** Converts type to GRASS GIS raster map type identifier.
+/** Converts type to GRASS raster map type identifier.
  *
  * Use `::value` to obtain the map type identifier.
  * When conversion is not possible, compile error about `value` not
@@ -201,25 +201,25 @@ struct GrassRasterMapType
 {
 };
 
-/** Specialization for GRASS GIS raster map type convertor */
+/** Specialization for GRASS raster map type convertor */
 template<>
 struct GrassRasterMapType<CELL> : std::integral_constant<RASTER_MAP_TYPE, CELL_TYPE>
 {
 };
 
-/** Specialization for GRASS GIS raster map type convertor */
+/** Specialization for GRASS raster map type convertor */
 template<>
 struct GrassRasterMapType<FCELL> : std::integral_constant<RASTER_MAP_TYPE, FCELL_TYPE>
 {
 };
 
-/** Specialization for GRASS GIS raster map type convertor */
+/** Specialization for GRASS raster map type convertor */
 template<>
 struct GrassRasterMapType<DCELL> : std::integral_constant<RASTER_MAP_TYPE, DCELL_TYPE>
 {
 };
 
-/** Write a Raster to a GRASS GIS raster map.
+/** Write a Raster to a GRASS raster map.
  *
  * When used, the template is resolved based on the parameter.
  */
@@ -286,7 +286,7 @@ inline void raster_to_grass(
 
 /** Overload of raster_to_grass()
  *
- * Converts PoPS date to GRASS GIS timestamp.
+ * Converts PoPS date to GRASS timestamp.
  */
 template<typename Number>
 inline void raster_to_grass(
@@ -315,7 +315,7 @@ typedef int Integer;
 // cost when using const char* as it would be if we use
 // const std::string& as parameter while supporting both.
 
-/** Wrapper to read GRASS GIS raster into floating point Raster */
+/** Wrapper to read GRASS raster into floating point Raster */
 template<typename String>
 inline pops::Raster<Float> raster_from_grass_float(
     String name, NullInputPolicy null_policy = DefaultNullInputPolicy)
@@ -323,7 +323,7 @@ inline pops::Raster<Float> raster_from_grass_float(
     return raster_from_grass<Float>(name, null_policy);
 }
 
-/** Wrapper to read GRASS GIS raster into integer type Raster */
+/** Wrapper to read GRASS raster into integer type Raster */
 template<typename String>
 inline pops::Raster<Integer> raster_from_grass_integer(
     String name, NullInputPolicy null_policy = DefaultNullInputPolicy)

--- a/main.cpp
+++ b/main.cpp
@@ -1012,7 +1012,7 @@ int main(int argc, char* argv[])
             std::stod(opt.percent_natural_dispersal->answer);
 
     // warn about limits to backwards compatibility
-    // "none" is consistent with other GRASS GIS modules
+    // "none" is consistent with other GRASS tools
     warn_about_depreciated_option_value(opt.natural_direction, "NONE", "none");
     warn_about_depreciated_option_value(opt.anthro_kernel, "NONE", "none");
     warn_about_depreciated_option_value(opt.anthro_direction, "NONE", "none");

--- a/r.pops.spread.html
+++ b/r.pops.spread.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-Module <em>r.pops.spread</em>
+Tool <em>r.pops.spread</em>
 is a dynamic species distribution model for pest or pathogen spread in forest
 or agricultural ecosystems. The model is process based
 meaning that it uses understanding of the effect of weather on reproduction
@@ -17,7 +17,7 @@ spread of the pest or pathogen into the future using simulation.
 <h3>About the model</h3>
 
 <p>
-The module is using the PoPS Core library which is implementing
+The tool is using the PoPS Core library which is implementing
 the PoPS model and it is a central part of the
 <a href="https://popsmodel.org/">Pest or Pathogen Spread (PoPS)</a> project.
 
@@ -38,18 +38,18 @@ version of the model was written in R, later with Rcpp (Tonini, 2017),
 and was based on Meentemeyer (2011) paper.
 
 <p>
-The current implementation of the GRASS GIS module is using PoPS Core
+The current implementation of the GRASS tool is using PoPS Core
 header-only C++ library which implements the PoPS model.
 The primary development of
 <a href="https://github.com/ncsu-landscape-dynamics/pops-core">PoPS Core</a>
 and of
-<a href="https://github.com/ncsu-landscape-dynamics/r.pops.spread">this module</a>
+<a href="https://github.com/ncsu-landscape-dynamics/r.pops.spread">this tool</a>
 happens in a
-separate repositories and GRASS GIS Addons repository contains the latest
+separate repositories and GRASS Addons repository contains the latest
 release of the model.
 An alternative
 <a href="https://github.com/ncsu-landscape-dynamics/r.pops.spread/tree/steering">steering version</a>
-of this module exists which includes a set of
+of this tool exists which includes a set of
 features supporting geospatial simulation steering (Petrasova, 2020)
 which is useful for exploring adaptive management scenarios.
 
@@ -72,7 +72,7 @@ a given use case is to go through one of the available tutorials.
 
 Typically, the model needs to be calibrated.
 You can obtain the calibration from a published work,
-colleague, calibrate the model manually (in GRASS GIS),
+colleague, calibrate the model manually (in GRASS),
 or use the R interface to PoPS called
 <a href="https://github.com/ncsu-landscape-dynamics/rpops">rpops</a>
 which has dedicated functions for calibration.
@@ -86,7 +86,7 @@ The directions of wind consider north (N) to be grid north, if your
 true north is different direction, you need to make an adjustment.
 
 <li>
-The module currently does not handle NULL (no data) as input, so you
+The tool currently does not handle NULL (no data) as input, so you
 need to change the NULLs to (most likely) zeros, for example:
 <code>r.null map=infection null=0</code>.
 
@@ -187,7 +187,7 @@ r.pops.spread host=host total_plants=all infected=infected_2005 \
 
 <h2>REFERENCES</h2>
 
-To cite this module, please refer to
+To cite this tool, please refer to
 <a href="https://github.com/ncsu-landscape-dynamics/r.pops.spread#how-to-cite">How to cite</a>
 section in the readme file.
 

--- a/r.pops.spread.html
+++ b/r.pops.spread.html
@@ -44,7 +44,7 @@ The primary development of
 <a href="https://github.com/ncsu-landscape-dynamics/pops-core">PoPS Core</a>
 and of
 <a href="https://github.com/ncsu-landscape-dynamics/r.pops.spread">this tool</a>
-happens in a
+happens in
 separate repositories and GRASS Addons repository contains the latest
 release of the model.
 An alternative

--- a/r.pops.spread.md
+++ b/r.pops.spread.md
@@ -32,7 +32,7 @@ header-only C++ library which implements the PoPS model. The primary
 development of [PoPS
 Core](https://github.com/ncsu-landscape-dynamics/pops-core) and of [this
 tool](https://github.com/ncsu-landscape-dynamics/r.pops.spread)
-happens in a separate repositories and GRASS Addons repository
+happens in separate repositories and GRASS Addons repository
 contains the latest release of the model. An alternative [steering
 version](https://github.com/ncsu-landscape-dynamics/r.pops.spread/tree/steering)
 of this tool exists which includes a set of features supporting

--- a/r.pops.spread.md
+++ b/r.pops.spread.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-Module *r.pops.spread* is a dynamic species distribution model for pest
+Tool *r.pops.spread* is a dynamic species distribution model for pest
 or pathogen spread in forest or agricultural ecosystems. The model is
 process based meaning that it uses understanding of the effect of
 weather on reproduction and survival of the pest or pathogen in order to
@@ -12,7 +12,7 @@ simulation.
 
 ### About the model
 
-The module is using the PoPS Core library which is implementing the PoPS
+The tool is using the PoPS Core library which is implementing the PoPS
 model and it is a central part of the [Pest or Pathogen Spread
 (PoPS)](https://popsmodel.org/) project.
 
@@ -27,15 +27,15 @@ was originally developed for *Phytophthora ramorum* and the original
 version of the model was written in R, later with Rcpp (Tonini, 2017),
 and was based on Meentemeyer (2011) paper.
 
-The current implementation of the GRASS GIS module is using PoPS Core
+The current implementation of the GRASS tool is using PoPS Core
 header-only C++ library which implements the PoPS model. The primary
 development of [PoPS
 Core](https://github.com/ncsu-landscape-dynamics/pops-core) and of [this
-module](https://github.com/ncsu-landscape-dynamics/r.pops.spread)
-happens in a separate repositories and GRASS GIS Addons repository
+tool](https://github.com/ncsu-landscape-dynamics/r.pops.spread)
+happens in a separate repositories and GRASS Addons repository
 contains the latest release of the model. An alternative [steering
 version](https://github.com/ncsu-landscape-dynamics/r.pops.spread/tree/steering)
-of this module exists which includes a set of features supporting
+of this tool exists which includes a set of features supporting
 geospatial simulation steering (Petrasova, 2020) which is useful for
 exploring adaptive management scenarios.
 
@@ -56,7 +56,7 @@ one of the available tutorials.
 
 Typically, the model needs to be calibrated. You can obtain the
 calibration from a published work, colleague, calibrate the model
-manually (in GRASS GIS), or use the R interface to PoPS called
+manually (in GRASS), or use the R interface to PoPS called
 [rpops](https://github.com/ncsu-landscape-dynamics/rpops) which has
 dedicated functions for calibration.
 
@@ -64,7 +64,7 @@ dedicated functions for calibration.
 
 - The directions of wind consider north (N) to be grid north, if your
     true north is different direction, you need to make an adjustment.
-- The module currently does not handle NULL (no data) as input, so you
+- The tool currently does not handle NULL (no data) as input, so you
     need to change the NULLs to (most likely) zeros, for example:
     `r.null map=infection null=0`.
 
@@ -160,7 +160,7 @@ r.pops.spread host=host total_plants=all infected=infected_2005 \
 
 ## REFERENCES
 
-To cite this module, please refer to [How to
+To cite this tool, please refer to [How to
 cite](https://github.com/ncsu-landscape-dynamics/r.pops.spread#how-to-cite)
 section in the readme file.
 


### PR DESCRIPTION
Update GRASS name after (GRASS GIS back to GRASS) rename. Also, use tool instead of a module.

Changes everything except the change log.

Names used only in the documentation, so there is no issue, but the disabled CI workflows need activity now.
