### PR TITLE
Add GRASS version 8.5 to CI

### DIFF
--- a/.github/workflows/ci-compiled.yml
+++ b/.github/workflows/ci-compiled.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         include:
         - version: main
+        - version: releasebranch_8_5
         - version: releasebranch_8_4
       fail-fast: false
 


### PR DESCRIPTION
Build and test also against the 8.5 branch, now after 8.5.0 release of GRASS. Keep 8.4 branch for now because it will be around for some time.
